### PR TITLE
chore: give docs workflow access to create docs PRs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -10,6 +10,10 @@ on:
       - "**/*.tpl"
       - "**/*.tf"
 
+permissions:
+  contents: write # Workflow needs to push new branches to open PRs with docs changes
+  pull-requests: write # Workflow needs to open PRs with docs changes
+
 jobs:
   tf-docs:
     name: TF docs


### PR DESCRIPTION
Pretty sure these are the right permissions but can't test them because it would require changing the action triggers in `main` first or forking the repo (which GitHub isn't allowing right now b/c the repo is private).  It's a cheap change so I say we merge and then test.