### PR TITLE
feat: add variables with defaults for Nutanix OS and Plan choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This POC is not intended to be used as a demonstration of best practices or Day-
 
 To accommodate deployment requirements, this module will create:
 
-- 1x [c3.small.x86](https://deploy.equinix.com/product/servers/c3-small/) node running [Ubuntu 22.04](https://deploy.equinix.com/developers/docs/metal/operating-systems/supported/#ubuntu) in a [hybrid-bonded networking mode](https://deploy.equinix.com/developers/docs/metal/layer2-networking/hybrid-bonded-mode/)
+- 1x [m3.small.x86](https://deploy.equinix.com/product/servers/m3-small/) node running [Ubuntu 22.04](https://deploy.equinix.com/developers/docs/metal/operating-systems/supported/#ubuntu) in a [hybrid-bonded networking mode](https://deploy.equinix.com/developers/docs/metal/layer2-networking/hybrid-bonded-mode/)
 
   This "bastion" node will act as a router and jump box. DHCP, DNS, and NAT (internet access) functionality will be provided by [`dnsmasq`](https://dnsmasq.org/doc.html).
 
@@ -138,9 +138,11 @@ ssh -i $(terraform output -raw ssh_private_key) $(terraform output -raw nutanix_
 
 ### On-Demand Instances
 
-This POC allocates a m3.small.x86 node for the Bastion host by default, you can change this to another instance type of your choosing by setting the `metal_bastion_plan` variable.
+This POC allocates a [m3.small.x86](https://deploy.equinix.com/product/servers/m3-small/) node for the Bastion host by default, you can change this to another instance type of your choosing by setting the `metal_bastion_plan` variable.
 
-This POC allocates m3.large.x86 instances for the Nutanix nodes. Additionally, only certain m3.large.x86 nodes will work, we recommed the AM and SL Metros for deployment. If a Nutanix node fails to provision, please try again until you get one that works. Production deployments should use qualified [Workload Optimized](https://deploy.equinix.com/developers/docs/metal/hardware/workload-optimized-plans/) instances for Nutanix nodes. This POC can be modified to use these instances by setting the `nutanix_reservation_ids` variable.
+This POC allocates [m3.large.x86](https://deploy.equinix.com/product/servers/m3-large/) instances for the Nutanix nodes. Additionally, only certain m3.large.x86 nodes will work. At time of writing, we recommend the SL or AM Metros for deployment. If a Nutanix node fails to provision, please try to `terraform apply` again. The failed node will fail to provision and will be removed from your project. Terraform will subsequently attempt to replace those servers.
+
+Production deployments should use qualified [Workload Optimized](https://deploy.equinix.com/developers/docs/metal/hardware/workload-optimized-plans/) instances for Nutanix nodes. You can work with an Equinix Metal sales to obtain a [hardware reservation](https://deploy.equinix.com/developers/docs/metal/deploy/reserved/) of known working m3.large.x86 for the Nutanix nodes. This will ensure that you get the correct hardware for your deployment.
 
 ### SSH failures while running on macOS
 

--- a/main.tf
+++ b/main.tf
@@ -125,8 +125,8 @@ resource "equinix_metal_device" "nutanix" {
   count            = var.nutanix_node_count
   project_id       = local.project_id
   hostname         = "nutanix-devrel-test-${count.index}"
-  operating_system = "nutanix_lts_6_5"
-  plan             = "m3.large.x86"
+  operating_system = var.metal_nutanix_os
+  plan             = var.metal_nutanix_plan
   metro            = var.metal_metro
 
   hardware_reservation_id          = lookup(local.nutanix_reservation_ids, count.index, null)

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -5,7 +5,9 @@
 # metal_organization_id="" # The ID of the Metal organization in which to create the project if `create_project` is true.
 # metal_metro="" # The metro to create the cluster in
 # create_project=true # (Optional) to use an existing project matching `metal_project_name`, set this to false.
-# metal_bastion_plan="c3.small.x86" # Which plan to use for the bastion host.
+# metal_bastion_plan="m3.small.x86" # Which plan to use for the bastion host.
+# metal_nutanix_os="nutanix_lts_6_5" # Which OS to use for the Nutanix nodes.
+# metal_nutanix_plan="m3.large.x86" # Which plan to use for the Nutanix nodes (must be Nutanix compatible, see https://deploy.equinix.com/developers/os-compatibility/)
 # create_vlan=true # Whether to create a new VLAN for this project.
 # metal_vlan_id=null # ID of the VLAN you wish to use. e.g. 1234
 # nutanix_node_count=3 # The number of Nutanix nodes to create.

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,7 @@ variable "metal_metro" {
   type        = string
   description = "The metro to create the cluster in."
 }
+
 variable "create_project" {
   type        = bool
   default     = true
@@ -49,7 +50,7 @@ variable "create_project" {
 
 variable "metal_bastion_plan" {
   type        = string
-  default     = "c3.small.x86"
+  default     = "m3.small.x86"
   description = "Which plan to use for the bastion host."
 }
 
@@ -62,6 +63,18 @@ variable "metal_vlan_id" {
   type        = number
   default     = null
   description = "ID of the VLAN you wish to use."
+}
+
+variable "metal_nutanix_os" {
+  type        = string
+  default     = "nutanix_lts_6_5"
+  description = "Which OS to use for the Nutanix nodes."
+}
+
+variable "metal_nutanix_plan" {
+  type        = string
+  default     = "m3.large.x86"
+  description = "Which plan to use for the Nutanix nodes (must be Nutanix compatible, see https://deploy.equinix.com/developers/os-compatibility/)"
 }
 
 variable "nutanix_node_count" {


### PR DESCRIPTION
Revises plan variables and docs so that bastion nodes are m3.small and Nutanix nodes are m3.large.  m3.small is chosen because c3.small is not available in metros where Nutanix compatible m3.large servers reside, also m3.small is more cost effective than c3.medium for this purpose.

This PR also makes the nutanix_metal_os and nutanix_metal_plan configurable. The default version is the only version that should be used today. This change makes it so that future versions known or expected to work (or be testable) can be applied to this module with minimal effort.