### PR TITLE
Feat timeout dhcp script

### DIFF
--- a/templates/dhcp-check.sh.tmpl
+++ b/templates/dhcp-check.sh.tmpl
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-#!/bin/sh
-
 # Timeout in seconds (20 minutes)
 timeout=1200
 # Number of nodes

--- a/templates/dhcp-check.sh.tmpl
+++ b/templates/dhcp-check.sh.tmpl
@@ -4,10 +4,11 @@
 timeout=1200
 # Number of nodes
 num_nodes=${num_nodes}
+# Counter initialization
+counter=0
 
 # Function to check leases existence
 check_leases_existence() {
-    counter=0
     until [ -f /var/lib/misc/dnsmasq.leases ] || [ "$counter" -ge "$timeout" ]; do
         echo "Waiting for /var/lib/misc/dnsmasq.leases to exist..."
         sleep 10

--- a/templates/dhcp-check.sh.tmpl
+++ b/templates/dhcp-check.sh.tmpl
@@ -3,6 +3,7 @@
 # Timeout in seconds (15 minutes)
 timeout=900
 
+counter=0
 until [ -f /var/lib/misc/dnsmasq.leases ] || [ "$counter" -ge "$timeout" ]; do
         echo "Waiting for /var/lib/misc/dnsmasq.leases to exist..."
         sleep 10

--- a/templates/dhcp-check.sh.tmpl
+++ b/templates/dhcp-check.sh.tmpl
@@ -1,38 +1,51 @@
 #!/bin/sh
 
-# Timeout in seconds (15 minutes)
-timeout=900
+#!/bin/sh
 
-counter=0
-until [ -f /var/lib/misc/dnsmasq.leases ] || [ "$counter" -ge "$timeout" ]; do
+# Timeout in seconds (20 minutes)
+timeout=1200
+# Number of nodes
+num_nodes=${num_nodes}
+
+# Function to check leases existence
+check_leases_existence() {
+    counter=0
+    until [ -f /var/lib/misc/dnsmasq.leases ] || [ "$counter" -ge "$timeout" ]; do
         echo "Waiting for /var/lib/misc/dnsmasq.leases to exist..."
         sleep 10
         counter=$((counter + 10))
-done
+    done
 
-if [ "$counter" -ge "$timeout" ]; then
-	echo "Timeout reached waiting for /var/lib/misc/dnsmasq.leases to exist."
-	exit 1
-fi
+    if [ "$counter" -ge "$timeout" ]; then
+        echo "Timeout reached waiting for /var/lib/misc/dnsmasq.leases to exist."
+        exit 1
+    fi
+}
 
-echo "Found /var/lib/misc/dnsmasq.leases. Examining leases."
+# Function to check leases count
+check_leases_count() {
+    found_leases=$(grep -c "NTNX" /var/lib/misc/dnsmasq.leases)
 
-found_leases=$(grep -c "NTNX" /var/lib/misc/dnsmasq.leases)
-
-until [ "$${found_leases}" -ge ${ 2 * num_nodes } ] || [ "$counter" -ge "$timeout" ]; do
-        echo "Waiting for at least ${ 2 * num_nodes } leases in /var/lib/misc/dnsmasq.leases, found $${found_leases}..."
+    # Note: we wait for "2 * num_nodes" beacuse each node runs the AHV hypervisor and the Nutanix CVM,
+    # each requiring its own IP address.
+    until [ "$${found_leases}" -ge $((2 * num_nodes)) ] || [ "$counter" -ge "$timeout" ]; do
+        echo "Waiting for at least $((2 * num_nodes)) leases in /var/lib/misc/dnsmasq.leases, found $${found_leases}..."
         found_leases=$(grep -c "NTNX" /var/lib/misc/dnsmasq.leases)
         sleep 10
         counter=$((counter + 10))
-done
+    done
 
-if [ "$counter" -ge "$timeout" ]; then
-	echo "Timeout reached waiting for at least ${ 2 * num_nodes } leases in /var/lib/misc/dnsmasq.leases, found $${found_leases}."
-	exit 1
-fi
+    if [ "$counter" -ge "$timeout" ]; then
+        echo "Timeout reached waiting for at least $((2 * num_nodes)) leases in /var/lib/misc/dnsmasq.leases, found $${found_leases}."
+        exit 1
+    fi
+}
 
-echo "Found the expected ${ 2 * num_nodes } leases in /var/lib/misc/dnsmasq.leases."
+# Main
+check_leases_existence
+echo "Found /var/lib/misc/dnsmasq.leases. Examining leases."
+check_leases_count
+echo "Found the expected $((2 * num_nodes)) leases in /var/lib/misc/dnsmasq.leases."
 
 echo "Sleeping for five minutes to let cluster networking stabilize"
-
 sleep 300

--- a/templates/dhcp-check.sh.tmpl
+++ b/templates/dhcp-check.sh.tmpl
@@ -1,21 +1,34 @@
 #!/bin/sh
 
-until [ -f /var/lib/misc/dnsmasq.leases ]
-do
+# Timeout in seconds (15 minutes)
+timeout=900
+
+until [ -f /var/lib/misc/dnsmasq.leases ] || [ "$counter" -ge "$timeout" ]; do
         echo "Waiting for /var/lib/misc/dnsmasq.leases to exist..."
-        sleep 5
+        sleep 10
+        counter=$((counter + 10))
 done
 
-echo "Found /var/lib/misc/dnsmasq.leases.  Examining leases."
+if [ "$counter" -ge "$timeout" ]; then
+	echo "Timeout reached waiting for /var/lib/misc/dnsmasq.leases to exist."
+	exit 1
+fi
+
+echo "Found /var/lib/misc/dnsmasq.leases. Examining leases."
 
 found_leases=$(grep -c "NTNX" /var/lib/misc/dnsmasq.leases)
 
-until [ "$${found_leases}" -ge ${ 2 * num_nodes } ]
-do
+until [ "$${found_leases}" -ge ${ 2 * num_nodes } ] || [ "$counter" -ge "$timeout" ]; do
         echo "Waiting for at least ${ 2 * num_nodes } leases in /var/lib/misc/dnsmasq.leases, found $${found_leases}..."
         found_leases=$(grep -c "NTNX" /var/lib/misc/dnsmasq.leases)
-        sleep 5
+        sleep 10
+        counter=$((counter + 10))
 done
+
+if [ "$counter" -ge "$timeout" ]; then
+	echo "Timeout reached waiting for at least ${ 2 * num_nodes } leases in /var/lib/misc/dnsmasq.leases, found $${found_leases}."
+	exit 1
+fi
 
 echo "Found the expected ${ 2 * num_nodes } leases in /var/lib/misc/dnsmasq.leases."
 


### PR DESCRIPTION
It would be strange for this to fail, but just in case, It's better to add a timeout to exit the while loop

On the other hand, I kept

```
echo "Sleeping for five minutes to let cluster networking stabilize"
sleep 300
```

but not sure whether we really need that and i's something that can be addressed in this pr