### PR TITLE
feat: reserve 3 IPs for common needs and add to outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "equinix_metal_device" "bastion" {
     host_dhcp_start = cidrhost(local.subnet, 3),
     host_dhcp_end   = cidrhost(local.subnet, 15),
     vm_dhcp_start   = cidrhost(local.subnet, 16),
-    vm_dhcp_end     = cidrhost(local.subnet, -2),
+    vm_dhcp_end     = cidrhost(local.subnet, -5),
     lease_time      = "infinite",
     nutanix_mac     = "50:6b:8d:*:*:*",
     set             = "nutanix"

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,19 @@ output "cvim_ip_address" {
   description = "The IP address of the CVM"
   value       = data.local_file.cvm_ip_address.content
 }
+
+output "virtual_ip_address" {
+  description = "Reserved IP for cluster virtal IP"
+  value       = cidrhost(local.subnet, -2)
+}
+
+output "iscsi_ip_address" {
+  description = "Reserved IP for cluster ISCSI IP"
+  value       = cidrhost(local.subnet, -3)
+}
+
+
+output "prism_central_ip_address" {
+  description = "Reserved IP for Prism Central VM"
+  value       = cidrhost(local.subnet, -4)
+}

--- a/templates/bastion-userdata.tmpl
+++ b/templates/bastion-userdata.tmpl
@@ -59,3 +59,4 @@ packages:
 runcmd:
 - sysctl -p /etc/sysctl.d/10-ip-forwarding.conf
 - systemctl restart networking
+- systemctl restart dnsmasq


### PR DESCRIPTION
- Reserve IP for Prism Central
- Reserve IP for cluster virtual ip
- Reserve IP for cluster ISCSI ip
- Adds dnsmasq restart after networking restart in cloud-init

Fixes https://github.com/equinix-labs/terraform-equinix-metal-nutanix-cluster/issues/59