### PR TITLE
Fix: removed relative paths, updated path.module prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "null_resource" "wait_for_firstboot" {
   }
 
   provisioner "remote-exec" {
-    script = "scripts/firstboot-check.sh"
+    script = "${path.module}/scripts/firstboot-check.sh"
   }
 }
 


### PR DESCRIPTION
The script source is missing a path.module prefix. Relative paths do not work appropriately in Terraform modules when accesses as a submodule.