### PR TITLE
feat: Update subnet configuration in main.tf to utilize the 'metal_subnet' variable.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@ output "nutanix_sos_hostname" {
 
 output "ssh_forward_command" {
   description = "SSH port forward command to use to connect to the Prism GUI"
-  value       = "ssh -L 9440:${data.local_file.cvm_ip_address.content}:9440 -L 19440:${cidrhost(local.subnet, -4)}:9440 -i ${module.ssh.ssh_private_key} root@${equinix_metal_device.bastion.access_public_ipv4}"
+  value       = "ssh -L 9440:${data.local_file.cvm_ip_address.content}:9440 -L 19440:${cidrhost(var.cluster_subnet, -4)}:9440 -i ${module.ssh.ssh_private_key} root@${equinix_metal_device.bastion.access_public_ipv4}"
 }
 
 output "cvim_ip_address" {
@@ -26,16 +26,16 @@ output "cvim_ip_address" {
 
 output "virtual_ip_address" {
   description = "Reserved IP for cluster virtal IP"
-  value       = cidrhost(local.subnet, -2)
+  value       = cidrhost(var.cluster_subnet, -2)
 }
 
 output "iscsi_data_services_ip" {
   description = "Reserved IP for cluster ISCSI Data Services IP"
-  value       = cidrhost(local.subnet, -3)
+  value       = cidrhost(var.cluster_subnet, -3)
 }
 
 
 output "prism_central_ip_address" {
   description = "Reserved IP for Prism Central VM"
-  value       = cidrhost(local.subnet, -4)
+  value       = cidrhost(var.cluster_subnet, -4)
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -12,4 +12,5 @@
 # metal_vlan_id=null # ID of the VLAN you wish to use. e.g. 1234
 # nutanix_node_count=3 # The number of Nutanix nodes to create.
 # skip_cluster_creation=false # Skip the creation of the Nutanix cluster.
+# cluster_subnet="192.168.140.0/22" # Pick an arbitrary private subnet, we recommend a /22 like "192.168.100.0/22"
 # nutanix_reservation_ids=[] # Hardware reservation IDs to use for the Nutanix nodes

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "metal_project_id" {
   EOT
 }
 
+variable "cluster_subnet" {
+  type        = string
+  default     = "192.168.100.0/22"
+  description = "nutanix cluster subnet"
+}
+
 variable "metal_organization_id" {
   type        = string
   default     = null


### PR DESCRIPTION

Refactor subnet configuration and comments

This commit refactors the subnet configuration in the 'main.tf' file to utilize the 'metal_subnet' variable instead of hardcoding the subnet value. Previously, an arbitrary subnet '192.168.100.0/22' was used directly within the file. By introducing the 'metal_subnet' variable, the configuration becomes more flexible and easier to manage, allowing users to specify their desired subnet for the Nutanix cluster.

Additionally, this commit removes redundant comments related to subnet configuration that were no longer necessary after the refactor. These comments provided guidance on selecting a subnet, which is now handled through the 'metal_subnet' variable, making the comments obsolete.

Overall, this refactor improves the maintainability and flexibility of the Terraform configuration for deploying Nutanix clusters on Equinix Metal infrastructure.
