### PR TITLE
docs: note the 0777 ssh problem in clearer terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Production deployments should use qualified [Workload Optimized](https://deploy.
 
 The Nutanix devices have `sshd` configured with `MaxSessions 1`. In most cases this is not a problem, but in our testing on macOS we observed frequent SSH connection errors. These connection errors can be resolved by turning off the SSH agent in your terminal before running `terraform apply`. To turn off your SSH agent in a macOS terminal, run `unset SSH_AUTH_SOCK`.
 
+Error messages that match this problem:
+
+* `Error chmodding script file to 0777 in remote machine: ssh: rejected: administratively prohibited (open failed)`
+
 ### Other Timeouts and Connection issues
 
 This POC project has not ironed out all potential networking and provisioning timing hiccups that can occur. In many situations, running `terraform apply` again will progress the deployment to the next step. If you do not see progress after 3 attempts, open an issue on GitHub: <https://github.com/equinix-labs/terraform-equinix-metal-nutanix-cluster/issues/new>.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The Nutanix devices have `sshd` configured with `MaxSessions 1`. In most cases t
 
 Error messages that match this problem:
 
-* `Error chmodding script file to 0777 in remote machine: ssh: rejected: administratively prohibited (open failed)`
+- `Error chmodding script file to 0777 in remote machine: ssh: rejected: administratively prohibited (open failed)`
 
 ### Other Timeouts and Connection issues
 


### PR DESCRIPTION
It is not obvious that this error message:
> Error chmodding script file to 0777 in remote machine: ssh: rejected: administratively prohibited (open failed)

Is a known "Mac SSH" problem. Make this error more discoverable.