### PR TITLE
fix: example nutanix_node_count must default to an odd number

### DIFF
--- a/examples/cluster-migration/variables.tf
+++ b/examples/cluster-migration/variables.tf
@@ -27,8 +27,12 @@ variable "create_project" {
 
 variable "nutanix_node_count" {
   type        = number
-  default     = 2
-  description = "The number of Nutanix nodes to create."
+  default     = 1
+  description = "The number of Nutanix nodes to create. This must be an odd number."
+  validation {
+    condition     = var.nutanix_node_count % 2 == 1
+    error_message = "The number of Nutanix nodes must be an odd number."
+  }
 }
 # tflint-ignore: terraform_unused_declarations
 variable "create_vlan" {


### PR DESCRIPTION
Deploying 2 nodes results in failures. 3 nodes and 1 nodes are successful, as mentioned in https://github.com/equinix-labs/terraform-equinix-metal-nutanix-cluster/issues/68#issuecomment-2287138974 and previous commits.